### PR TITLE
doc auto-deploy via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: julia
+
 os:
   - linux
+
 julia:
   - 0.5
+
 notifications:
   email: false
+
 sudo: false
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("MarketTechnicals"); Pkg.test("MarketTechnicals")'
+
+after_success:
+  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'cd(Pkg.dir("MarketTechnicals", "docs")); include("make.jl")'

--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ MarketTechnicals.jl
 [![Build Status](https://travis-ci.org/JuliaQuant/MarketTechnicals.jl.svg?branch=master)](https://travis-ci.org/JuliaQuant/MarketTechnicals.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaQuant/MarketTechnicals.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaQuant/MarketTechnicals.jl?branch=master)
 [![MarketTechnicals](http://pkg.julialang.org/badges/MarketTechnicals_0.5.svg)](http://pkg.julialang.org/?pkg=MarketTechnicals&ver=0.5)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaQuant.github.io/MarketTechnicals.jl/latest/)
 
-A toolkit for technical analysis of financial time series in Julia, with documentation provided [here.](http://markettechnicals.readthedocs.org/en/latest/)
+A toolkit for technical analysis of financial time series in Julia, with documentation provided [here.](https://JuliaQuant.github.io/MarketTechnicals.jl/latest/)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,3 +16,12 @@ makedocs(
         "candlesticks.md",
     ]
 )
+
+deploydocs(
+    repo = "github.com/APCLab/MarketTechnicals.jl.git",
+    julia  = "0.5",
+    latest = "master",
+    target = "build",
+    deps = nothing,  # we use the `format = :html`, without `mkdocs`
+    make = nothing,  # we use the `format = :html`, without `mkdocs`
+)


### PR DESCRIPTION
@milktrader I need your help to deal with deploy key[1]. I do not have permission to add it.
After the key be added, please merge this PR. Documenter only push to `gh-pages` on `master` branch built or we push a new tag.
I have tried this PR on my forked repo[2].

1. https://juliadocs.github.io/Documenter.jl/stable/man/hosting.html#SSH-Deploy-Keys-1
2. https://apclab.github.io/MarketTechnicals.jl/latest/