### PR TITLE
macd: widen to accept multi-column TimeArray

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * macd: rename original `macd` column to `dif`,
   and add the macd osc bar as `macd`.
 
+* macd: widen to accept multi-column `TimeArray`.
+
 ### 0.5.0
 
 * support floor of julia 0.5.0

--- a/src/momentum.jl
+++ b/src/momentum.jl
@@ -72,10 +72,22 @@ Moving Average Convergence / Divergence
         DEM & = EMA(DIF, 9) \tag{signal}
     \end{align*}
 ```
+
+*Return*:
+    `TimeArray` with 3 columns `["macd", "dif", "signal"]`.
+
+    If the input is a multi-column `TimeArray`, the new column names will be
+    `["A_macd", "B_macd", "A_dif", "B_dif", "A_signal", "B_signal"]`.
+
 """
-function macd{T}(ta::TimeArray{T,1}, fast::Int=12, slow::Int=26, signal::Int=9)
+function macd{T,N}(ta::TimeArray{T,N},
+                   fast::Int=12, slow::Int=26, signal::Int=9)
     dif = ema(ta, fast) .- ema(ta, slow)
     sig = ema(dif, signal)
     osc = dif .- sig
-    merge(merge(osc, dif), sig, colnames=["macd", "dif", "signal"])
+
+    cols = ["macd", "dif", "signal"]
+    new_cols = (N > 1) ? gen_colnames(ta.colnames, cols) : cols
+
+    merge(merge(osc, dif), sig, colnames=new_cols)
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -13,3 +13,23 @@ function mean_abs_dev{T}(a::Array{T,1}, scale::Bool=false)
 
     mean(res) * c
 end
+
+"""
+Parameters:
+    * orig: the original colnames
+    * suffix: the suffix applied to `orig`
+
+```jldoctest
+julia> gen_colnames(["Open", "Close"], ["macd", "dif", "sig"])
+6-element Array{String,1}:
+ "Open_macd"
+ "Close_macd"
+ "Open_dif"
+ "Close_dif"
+ "Open_sig"
+ "Close_sig"
+```
+"""
+function gen_colnames(orig::Vector{String}, suffix::Vector{String})
+   vec(["$o\_$s" for o ∈ orig, s ∈ suffix])
+end

--- a/test/momentum.jl
+++ b/test/momentum.jl
@@ -27,6 +27,18 @@ facts("Momentum") do
         @fact macd(cl).timestamp[end] --> Date(2001,12,31)
     end
 
+    context("macd multi-column TimeArray") do
+        # multi-column TimeArray
+        # TTR: MACD(..., maType="EMA", percent=0)
+        ta = macd(ohlc["Open", "Close"])
+        @fact ta.colnames[1:2]        --> ["Open_macd", "Close_macd"]
+        @fact ta.values[end, 3]       --> roughly(0.44254569, atol=.01)    # Open_dif
+        @fact ta.values[end, 5]       --> roughly(4.536854e-01, atol=.01)  # Open_signal
+        @fact ta.values[end, 4]       --> roughly(0.421175152, atol=.01)   # Close_dif
+        @fact ta.values[end, 6]       --> roughly(4.414275e-01, atol=.01)  # Close_signal
+        @fact ta.timestamp[end]       --> Date(2001, 12, 31)
+    end
+
      context("cci") do
         @fact cci(ohlc).values[1]      --> roughly(360.765, atol=01)      # TTR::CCI value is -38.931614
         @fact cci(ohlc).values[end]    --> roughly(44.651, atol=.01)      # TTR::CCI value is 46.3511339


### PR DESCRIPTION
```julia
julia> macd(ohlc["Open", "Close"])
467x6 TimeSeries.TimeArray{Float64,2,Date,Array{Float64,2}} 2000-02-18 to 2001-12-31

             Open_macd  Close_macd  Open_dif  Close_dif  Open_signal  Close_signal  
2000-02-18 | 0.5907     -0.0472     3.3076    3.5339     2.717        3.5811        
2000-02-22 | 0.1396     -0.1375     2.8914    3.4092     2.7518       3.5467        
2000-02-23 | 0.0229     -0.0636     2.7805    3.4672     2.7576       3.5308        
2000-02-24 | 0.1838     -0.1131     2.9873    3.3894     2.8035       3.5026        
⋮
2001-12-26 | -0.1753    -0.1494     0.3343    0.3244     0.5096       0.4738        
2001-12-27 | -0.1333    -0.0861     0.3431    0.3661     0.4763       0.4523        
2001-12-28 | -0.0794    -0.0231     0.3771    0.4234     0.4565       0.4465        
2001-12-31 | -0.0111    -0.0203     0.4425    0.4212     0.4537       0.4414        

```