### PR TITLE
naming consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 docs/build
+src/.rc.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,6 +3,26 @@
 The MarketTechnicals package provides common technical analysis algorithms
 for financial time series.
 
+## Naming Convention
+
+This package names its method by spelling out the entire name without
+camel casing or underscores, which is typical for the Julia programming
+language. In special cases where an abbreviation is widely recognized,
+it is used instead. For example, the `rsi`, `cci` and `adx` methods are
+abbreviated while `chaikinvolatility` is spelled out.
+
+For those who find this naming convention too cumbersome, an
+`src/.rc.jl` file is provided. It has been added to the `.gitignore` file so
+whatever modifications or customizations you make there will not be corrupted
+with each package update.
+An example of using this to rename methods would be to include the following
+line:
+
+```julia
+export cvola
+
+cvola = chaikinvolatility
+```
 
 ## Contents
 

--- a/docs/src/momentum.md
+++ b/docs/src/momentum.md
@@ -55,14 +55,14 @@ macd(cl)
 ## Chaikin Oscillator
 
 ```@docs
-chaikin_osc
+chaikinoscillator
 ```
 
 ```@repl
 using MarketData
 using MarketTechnicals
 
-chaikin_osc(ohlcv)
+chaikinoscillator(ohlcv)
 ```
 
 ## CCI

--- a/docs/src/momentum.md
+++ b/docs/src/momentum.md
@@ -94,12 +94,12 @@ roc(cl, 5)
 ## Stochastic Oscillator
 
 ```@docs
-stoch_osc
+stochasticoscillator
 ```
 
 ```@repl
 using MarketData
 using MarketTechnicals
 
-stoch_osc(ohlc)
+stochasticoscillator(ohlc)
 ```

--- a/docs/src/volatility.md
+++ b/docs/src/volatility.md
@@ -55,14 +55,14 @@ atr(ohlc)
 ## Donchian Channels
 
 ```@docs
-donchian_channels
+donchianchannels
 ```
 
 ```@repl
 using MarketData
 using MarketTechnicals
 
-donchian_channels(ohlc)
+donchianchannels(ohlc)
 ```
 
 ## Keltner Bands

--- a/src/MarketTechnicals.jl
+++ b/src/MarketTechnicals.jl
@@ -10,7 +10,7 @@ export sma, ema, kama,
        bollingerbands, truerange, atr, keltnerbands, chaikinvolatility, donchian_channels,
        obv, vwap, adl,
        doji,
-       rsi, macd, cci, roc, adx, stoch_osc, chaikin_osc, aroon,
+       rsi, macd, cci, roc, adx, stoch_osc, chaikinoscillator, aroon,
        floorpivots, woodiespivots,
        typical
 

--- a/src/MarketTechnicals.jl
+++ b/src/MarketTechnicals.jl
@@ -7,7 +7,7 @@ module MarketTechnicals
 using TimeSeries, StatsBase
 
 export sma, ema, kama,
-       bollingerbands, truerange, atr, keltnerbands, chaikinvolatility, donchian_channels,
+       bollingerbands, truerange, atr, keltnerbands, chaikinvolatility, donchianchannels,
        obv, vwap, adl,
        doji,
        rsi, macd, cci, roc, adx, stoch_osc, chaikinoscillator, aroon,

--- a/src/MarketTechnicals.jl
+++ b/src/MarketTechnicals.jl
@@ -10,7 +10,7 @@ export sma, ema, kama,
        bollingerbands, truerange, atr, keltnerbands, chaikinvolatility, donchianchannels,
        obv, vwap, adl,
        doji,
-       rsi, macd, cci, roc, adx, stoch_osc, chaikinoscillator, aroon,
+       rsi, macd, cci, roc, adx, stochasticoscillator, chaikinoscillator, aroon,
        floorpivots, woodiespivots,
        typical
 

--- a/src/MarketTechnicals.jl
+++ b/src/MarketTechnicals.jl
@@ -22,4 +22,13 @@ include("utilities.jl")
 include("volatility.jl")
 include("volume.jl")
 
+# for user customization
+# FIXME: using @__DIR__ while we upgrade to julia 0.6+
+RC_FILE = joinpath(dirname(@__FILE__), ".rc.jl")
+if !ispath(RC_FILE)
+    touch(RC_FILE)
+end
+
+include(RC_FILE)
+
 end

--- a/src/momentum.jl
+++ b/src/momentum.jl
@@ -203,7 +203,7 @@ function adx{T,N}(ohlc::TimeArray{T,N}, n::Integer=14;
 end
 
 doc"""
-    stoch_osc(ohlc, n=14, fast_d=3, slow_d=3; h="High", l="Low", c="Close")
+    stochasticoscillator(ohlc, n=14, fast_d=3, slow_d=3; h="High", l="Low", c="Close")
 
 **Stochastic Oscillator**
 
@@ -237,8 +237,8 @@ A.k.a *%K%D*, or *KD*
 - [FMLabs]
   (http://www.fmlabs.com/reference/default.htm?url=StochasticOscillator.htm)
 """
-function stoch_osc(ohlc::TimeArray, n::Integer=14, fast_d::Integer=3,
-                   slow_d::Integer=3; h="High", l="Low", c="Close")
+function stochasticoscillator(ohlc::TimeArray, n::Integer=14, fast_d::Integer=3,
+                              slow_d::Integer=3; h="High", l="Low", c="Close")
     high = moving(ohlc[h], maximum, n)
     low = moving(ohlc[l], minimum, n)
     fast_k = rename((ohlc[c] .- low) ./ (high .- low) * 100, "fast_k")

--- a/src/momentum.jl
+++ b/src/momentum.jl
@@ -60,7 +60,7 @@ function cci{T,N}(ohlc::TimeArray{T,N}, ma::Int=20, c::AbstractFloat=0.015)
 end
 
 doc"""
-    chaikin_osc(ohlcv, fast=3, slow=10; h="High", l="Low", c="Close")
+    chaikinoscillator(ohlcv, fast=3, slow=10; h="High", l="Low", c="Close")
 
 **Chaikin Oscillator**
 
@@ -79,10 +79,10 @@ where the [`adl`](@ref) is the Accumulation/Distribution Line.
 - [StockCharts]
   (http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:chaikin_oscillator)
 """
-function chaikin_osc(ohlcv::TimeArray, fast::Integer=3, slow::Integer=10;
-                     h="High", l="Low", c="Close")
+function chaikinoscillator(ohlcv::TimeArray, fast::Integer=3, slow::Integer=10;
+                           h="High", l="Low", c="Close")
     _adl = adl(ohlcv, h=h, l=l, c=c)
-    rename(ema(_adl, fast) .- ema(_adl, slow), ["chaikin_osc"])
+    rename(ema(_adl, fast) .- ema(_adl, slow), ["chaikinoscillator"])
 end
 
 doc"""

--- a/src/volatility.jl
+++ b/src/volatility.jl
@@ -23,7 +23,7 @@ function bollingerbands{T,N}(ta::TimeArray{T,N}, ma::Integer=20,
 end
 
 doc"""
-    donchian_channels(ta, n=20; h="High", l="Low")
+    donchianchannels(ta, n=20; h="High", l="Low")
 
 **Donchian Channels**
 
@@ -43,7 +43,7 @@ doc"""
   (https://www.tradingview.com/wiki/Donchian_Channels_(DC))
 
 """
-function donchian_channels(ta::TimeArray, n::Integer=20; h="High", l="Low")
+function donchianchannels(ta::TimeArray, n::Integer=20; h="High", l="Low")
     up = rename(moving(ta[h], maximum, n), "up")
     down = rename(moving(ta[l], minimum, n), "down")
     mid = rename((up .+ down) ./ 2, "mid")

--- a/test/momentum.jl
+++ b/test/momentum.jl
@@ -138,7 +138,7 @@ end
 end
 
 
-@testset "stochastic osc" begin
+@testset "stochasticoscillator" begin
     """
     Quote from TTR
     > stoch(x[, c("High", "Low", "Close")], maType=SMA)
@@ -155,7 +155,7 @@ end
     [27,] 0.801061008 0.76010676 0.64559114
     [28,] 0.839964633 0.79861349 0.73949111
     """
-    ta = stoch_osc(ohlc)
+    ta = stochasticoscillator(ohlc)
     @test ta.colnames  == ["fast_k", "fast_d", "slow_d"]
     @test ta.timestamp == ohlc[18:end].timestamp
     @test isapprox(ta.values[1, 1], 67.142857, atol=.01)

--- a/test/momentum.jl
+++ b/test/momentum.jl
@@ -52,7 +52,7 @@ end
 end
 
 
-@testset "chaikin_osc" begin
+@testset "chaikinoscillator" begin
     """
     Quote from TTR
 
@@ -76,8 +76,8 @@ end
     [81]   1214832.531   1341044.310   1592063.283    936678.383    186056.580
     [86]  -1209996.220  -1516911.058  -1995687.520  -2776094.760  -4090715.405
     """
-    ta = chaikin_osc(ohlcv)
-    @test ta.colnames     == ["chaikin_osc"]
+    ta = chaikinoscillator(ohlcv)
+    @test ta.colnames     == ["chaikinoscillator"]
     @test ta.meta         == ta.meta
     @test ta.timestamp[1] == ohlcv.timestamp[10]
     @test isapprox(ta.values[1], -6851466.867, atol=.01)

--- a/test/volatility.jl
+++ b/test/volatility.jl
@@ -27,8 +27,8 @@ end
 end
 
 
-@testset "donchian_channels" begin
-    ta = donchian_channels(ohlc)
+@testset "donchianchannels" begin
+    ta = donchianchannels(ohlc)
 
     @test ta.meta      == ohlc.meta
     @test ta.timestamp == ohlc[20:end].timestamp


### PR DESCRIPTION
@milktrader I think it is time to roll out a new release, and I want to sort out the naming of those functions/output columnes.
I need your comment and sort out a consistent naming policy.

Here are some questions came to my mind:
* Some output columes will append the parameter of the indicator but some not.
  e.g. [SMA](https://juliaquant.github.io/MarketTechnicals.jl/latest/ma.html#Simple-Moving-Average-1) does, but [MACD](https://juliaquant.github.io/MarketTechnicals.jl/latest/momentum.html#MACD-1) not

* For some indicators which has long full name, I prefer to name them briefly (and with a underline). 
  e.g. [chaikin_osc](https://juliaquant.github.io/MarketTechnicals.jl/latest/momentum.html#Chaikin-Oscillator-1) instead of `chaikinoscillator`. 

