### PR TITLE
kama: fix case of NaN output

### DIFF
--- a/src/movingaverages.jl
+++ b/src/movingaverages.jl
@@ -48,7 +48,8 @@ end
 function kama(ta::TimeArray{T,N}, n::Int=10, fn::Int=2, sn::Int=30) where {T,N}
     vola = moving(sum, abs.(ta .- lag(ta)), n)
     change = abs.(ta .- lag(ta, n))
-    er = change ./ vola  # Efficiency Ratio
+    f = (x, y) -> (iszero(x) && iszero(y)) ? x : x / y
+    er = f.(change, vola)  # Efficiency Ratio
 
     # Smooth Constant
     sc = (er .* (2 / (fn + 1) - 2 / (sn + 1)) .+ 2 / (sn + 1)).^2

--- a/test/movingaverages.jl
+++ b/test/movingaverages.jl
@@ -78,6 +78,9 @@ using MarketTechnicals
 
         ta = kama(TimeArray(collect(Date(2011, 1, 1):Date(2011, 1, 20)), 1:20))
         @test ta.timestamp[end] == Date(2011, 1, 20)
+
+        ta = kama(TimeArray(collect(Date(2011, 1, 1):Date(2011, 1, 20)), fill(42, 20)))
+        @test ta.values == fill(42, length(ta))
     end
 end
 


### PR DESCRIPTION
Give a time series that the values are all the same,
`kama` returned NaN.