### PR TITLE
compat version updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MarketTechnicals"
 uuid = "4f8c86c6-9e40-5506-9807-98571cb48bc8"
 authors = ["JuliaQuant <https://github.com/JuliaQuant>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 MarketData = "945b72a4-3b13-509d-9b46-1525bb5c06de"
@@ -11,10 +11,10 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [compat]
-MarketData = "0.13"
+MarketData = "0.13, 0.15"
 Reexport = "0.2, 1.0"
-StatsBase = "0.32, 0.33"
-TimeSeries = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
+StatsBase = "0.32, 0.33, 0.34"
+TimeSeries = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
 julia = "1.1"
 
 [extras]


### PR DESCRIPTION
Updating some compat version entries that were preventing precompilation of CUDA.jl related packages on Julia 1.11